### PR TITLE
Added logging and set client to continuously update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .idea
 **/.cache
 **/__pycache__
+client_log.log
+client_log.log.1
+server_log.log
+server_log.log.1

--- a/client.py
+++ b/client.py
@@ -1,11 +1,38 @@
 import http.client
 import sys
+import logging
+from time import sleep
+from logging.handlers import RotatingFileHandler
 
-server_ip = sys.argv[1]
-#server_ip = "127.0.1.10"
-x = http.client.HTTPConnection(server_ip, 9999)
-x.connect()
-x.request('GET', '/img/imgs-listen.txt')
-y = x.getresponse()
-z = y.read()
-print(z)
+# setup logger and log format
+logging.basicConfig(level=logging.DEBUG, format = '[%(levelname)s] %(asctime)s | %(module)s | %(message)s')
+logger = logging.getLogger(__name__)
+
+# setup file handler to write logs to a file
+debughandler = RotatingFileHandler('client_log.log', maxBytes = 1048576, backupCount = 1)
+debughandler.setLevel(logging.DEBUG) #set debug handler level to debug
+formatter = logging.Formatter('[%(levelname)s] %(asctime)s | %(module)s | %(message)s')
+debughandler.setFormatter(formatter)
+
+#adds file handler to logger
+logger.addHandler(debughandler)
+
+while True:
+    #server_ip = sys.argv[1]
+    try:
+        server_ip = "127.0.1.20"
+        logger.debug('Target server IP: %s',server_ip)
+        x = http.client.HTTPConnection(server_ip, 9999)
+        x.connect()
+        x.request('GET', '/imgs/imgs-listen.txt')
+
+        y = x.getresponse()
+        z = y.read()
+        logger.info('GET Response received: %s',z)
+        sleep(0.5)
+    except ConnectionRefusedError:
+        logger.error('Connection refused! Server may be offline. Retrying in 5s...')
+        sleep(5)
+    except ConnectionResetError:
+        logger.error('Connected reset! Server may have stopped. Retrying in 5s...')
+        sleep(5)

--- a/server.py
+++ b/server.py
@@ -1,54 +1,72 @@
 import http.server
 import os
 import sys
+import logging #logging library for info, error, etc messages
+from logging.handlers import RotatingFileHandler
 
 # load custom deployment settings
 from settings import SERVER_BASE_DIR, PORT
 
-IMGS_DIR_LISTING_FILEPATH = '/imgs/imgs-listing.txt'
+# setup logger and log format
+logging.basicConfig(level=logging.DEBUG, format = '[%(levelname)s] %(asctime)s | %(module)s | %(message)s')
+logger = logging.getLogger(__name__)
 
-def updateImagesDirectoryListing():
+# setup file handler to write logs to a file
+debughandler = RotatingFileHandler('server_log.log', maxBytes = 1048576, backupCount = 1)
+debughandler.setLevel(logging.DEBUG) #set debug handler level to debug
+formatter = logging.Formatter('[%(levelname)s] %(asctime)s | %(module)s | %(message)s')
+debughandler.setFormatter(formatter)
+
+#adds file handler to logger
+logger.addHandler(debughandler)
+
+IMGS_DIR_LISTING_FILEPATH = '/imgs/imgs-listen.txt'
+logger.debug('Imgs Directory Filepath: %s', IMGS_DIR_LISTING_FILEPATH)
+
+def updateImagesDirectoryListing(): # Updates the imgs-listen.txt file to represent the current /imgs directory contents
     with open(SERVER_BASE_DIR + IMGS_DIR_LISTING_FILEPATH, 'w') as f:
         dir_listing = os.listdir(SERVER_BASE_DIR + '/imgs') 
                                                 # get a list of all imgs in directory
         for item in dir_listing:
             f.write('{}\n'.format(item)) # only keep image filename
+    logger.debug('Updated images directory successfully')
 
 class ServerRequestHandler(http.server.BaseHTTPRequestHandler):
 
     # don't override __init__() method
 
     def do_GET(self):
-        print('Received a GET request')
-        self.send_response(200) # server is OK
+        logger.info('Received a GET request')
+        self.send_response(200,'OK') # server is OK
 
-        # if self.path == IMGS_DIR_LISTING_FILEPATH:
-        #     updateImagesDirectoryListing()
+        if self.path == IMGS_DIR_LISTING_FILEPATH:
+            updateImagesDirectoryListing()
 
-        # self.send_header('Content-type', 'text/plain')
-        # self.end_headers()
+        self.send_header('Content-type', 'text/plain')
+        self.end_headers()
 
-        # # send requested file
+        # send requested file
         # with open(SERVER_BASE_DIR + self.path, 'rb') as f:
-        #     self.wfile.write(f.read())
+        #    self.wfile.write(f.read())
         # f.close()
 
     def do_POST(self):
-        print('Received a POST request')
+        logger.info('Received a POST request')
 
 def run(server_ip):
     server_addr = (server_ip, PORT) # define network addr of this machine
 
     httpd = http.server.HTTPServer(server_addr, ServerRequestHandler) # create the server
-    print('Server is running...')
+    logger.info('Server is running...')
     httpd.serve_forever() # begin listening for events
+
 
 if __name__ == "__main__":
 
     # parse arguments for server configuration
-    server_ip = sys.argv[1]
+    #server_ip = sys.argv[1]
 
-    #server_ip = '127.0.1.20'
-    print('Starting the server at {}:{}, with filesystem root directory set to {}'.format(server_ip, PORT, SERVER_BASE_DIR))
+    server_ip = '127.0.1.20'
+    logger.info('Starting the server at {}:{}, with filesystem root directory set to {}'.format(server_ip, PORT, SERVER_BASE_DIR))
 
     run(server_ip) # start up the server


### PR DESCRIPTION
print() statements are replaced with logger statements which display in the console and are saved to a log which grows to a max of 1MB before cycling. On (temporary?) client side, will run in a continuous loop updating index file, or upon error will attempt to reconnect.